### PR TITLE
rename zstd-rs to libzstd-rs

### DIFF
--- a/content/blog/Compression compiler contributions.md
+++ b/content/blog/Compression compiler contributions.md
@@ -5,7 +5,7 @@ authors = ["Folkert de Vries"]
 date = "2026-03-30"
 
 [taxonomies]
-tags = ["bzip2-rs", "zlib-rs", "zstd-rs", "data compression"] 
+tags = ["bzip2-rs", "zlib-rs", "libzstd-rs", "data compression"]
 
 +++
 
@@ -13,7 +13,7 @@ In our data compression projects, we use Rust where C is traditionally used. Dur
 
 <!-- more -->
 
-Previously, we felt stuck at times by missing functionality in stable Rust, without a clear path forward except to wait. In practice, waiting has not been a fruitful strategy: the features we need are niche and rarely make it to the top of Rust maintainers' to-do lists. 
+Previously, we felt stuck at times by missing functionality in stable Rust, without a clear path forward except to wait. In practice, waiting has not been a fruitful strategy: the features we need are niche and rarely make it to the top of Rust maintainers' to-do lists.
 
 In this post, I'll share some of the steps we took to get unstuck. It goes over some of the fixes and improvements that we've made as a part of Trifecta Tech's [Data compression initiative](/initiatives/data-compression) (`zlib-rs`, `libbzip2-rs` and `libzstd-rs-sys`) over the past year.
 
@@ -73,7 +73,7 @@ Along the way it turned out that the implementation of the related `ptr_offset_w
 
 ### Improved intrinsic support
 
-We use Miri to test the unsafe code that we still have. I recently wrote about our work on [emulating avx-512 intrinsics in Miri](https://trifectatech.org/blog/emulating-avx-512-intrinsics-in-miri/). Since then we've added support for a couple additional instructions for our `avx512vnni` implementation of adler32. 
+We use Miri to test the unsafe code that we still have. I recently wrote about our work on [emulating avx-512 intrinsics in Miri](https://trifectatech.org/blog/emulating-avx-512-intrinsics-in-miri/). Since then we've added support for a couple additional instructions for our `avx512vnni` implementation of adler32.
 
 My next goal is to also be able to run the zlib-rs AArch64 SIMD tests with Miri. For now that'll need some additional support in Miri itself, but with LLVM 23 we'll be able to only use portable intrinsics and the custom Miri support should no longer be needed.
 
@@ -81,7 +81,7 @@ I want to stress that the Miri implementation is really only half the work. The 
 
 ### ICE when reading from a static array of function pointers
 
-In the first week of working on [libzstd-rs-sys](https://github.com/trifectatechfoundation/libzstd-rs-sys) we ran into `c2rust` producing some Rust code that Miri was unable to handle.  
+In the first week of working on [libzstd-rs-sys](https://github.com/trifectatechfoundation/libzstd-rs-sys) we ran into `c2rust` producing some Rust code that Miri was unable to handle.
 
 [https://github.com/rust-lang/miri/issues/4501](https://github.com/rust-lang/miri/issues/4501)
 
@@ -144,7 +144,7 @@ Rust can call c-variadic functions (like `libc::printf`), but defining them is u
 
 ```rust
 pub unsafe extern "C" fn gzprintf(
-    file: gzFile, 
+    file: gzFile,
     format: *const c_char,
     va: ...) -> c_int {
     unsafe { gzvprintf(file, format, va) }

--- a/content/initiatives/data-compression.md
+++ b/content/initiatives/data-compression.md
@@ -11,22 +11,22 @@ summary = "<p>Almost all content sent over the Internet undergoes data compressi
 
 projects = [
     "zlib-rs",
-    "zstd-rs",
+    "libzstd-rs",
     "bzip2-rs"
 ]
 
 funders = [
-    "nlnetfoundation", 
-    "chainguard", 
+    "nlnetfoundation",
+    "chainguard",
     "ngi-zero-core",
     "min-bzk",
     "astral"
 ]
 
 supporters = [
-    "devolutions", 
-    "prossimo", 
-    "tweedegolf", 
+    "devolutions",
+    "prossimo",
+    "tweedegolf",
     "isrg"
 ]
 
@@ -68,12 +68,12 @@ In June 2025 we released a new version of the **bzip2** crate, see [the bzip2 pr
 
 ### What's Next
 
-Development of **zstd** began in July 2025, with the first release of the decoder planned for February 2026. We're currently seeking funding to complete work on the encoder side, see [Zstandard in Rust](/projects/zstd-rs/). 
+Development of **zstd** began in July 2025, with the first release of the decoder planned for February 2026. We're currently seeking funding to complete work on the encoder side, see [Zstandard in Rust](/projects/libzstd-rs/).
 
 Meanwhile, work on zlib-rs and bzip2-rs continues to improve the implementations, enhance performance, and expand adoption.
 
 ### Roadmap
 
-See the [zlib-rs](/projects/zlib-rs/), [bzip2-rs](/projects/bzip2-rs/) and [Zstandard in Rust](/projects/zstd-rs/) project pages.
+See the [zlib-rs](/projects/zlib-rs/), [bzip2-rs](/projects/bzip2-rs/) and [Zstandard in Rust](/projects/libzstd-rs/) project pages.
 
 Please [get in touch with us](/support), if you are interested in financially supporting our data compression projects.

--- a/content/initiatives/workplans/workplan-zstd-rs.md
+++ b/content/initiatives/workplans/workplan-zstd-rs.md
@@ -1,11 +1,11 @@
 +++
 
 title = "Zstandard in Rust"
-slug = "zstd-rs"
+slug = "libzstd-rs"
 template = "initiatives/workplans/workplan.html"
 
 [extra]
-backLink = "projects/zstd-rs"
+backLink = "projects/libzstd-rs"
 backTitle = "Back to project: Zstandard in Rust"
 +++
 

--- a/content/projects/libzstd-rs.md
+++ b/content/projects/libzstd-rs.md
@@ -1,6 +1,6 @@
 +++
 title = "Zstandard in Rust"
-slug = "zstd-rs"
+slug = "libzstd-rs"
 template = "projects/project.html"
 
 [extra]
@@ -47,7 +47,7 @@ We thank [Chainguard](https://www.chainguard.dev/), [Astral](https://astral.sh/)
 - 2026 Q1: release of decoder
 - 2026 Q2: start of encoder implementation (*pending funding*)
 
-For details see [the workplan](/initiatives/workplans/zstd-rs/).
+For details see [the workplan](/initiatives/workplans/libzstd-rs/).
 
 ### Support Zstandard in Rust
 

--- a/static/data/funders.json
+++ b/static/data/funders.json
@@ -150,13 +150,13 @@
         "projects": [
             {
                 "initiative": "data-compression",
-                "name": "zlib-rs",
+                "name": "libzlib-rs",
                 "year": [2024],
                 "supportType": "Chainguard funded initial development of zlib-rs through Prossimo."
             },
             {
                 "initiative": "data-compression",
-                "name": "zstd-rs",
+                "name": "libzstd-rs",
                 "year": [2025]
             }
         ]


### PR DESCRIPTION
Just the rename for now (so updates to the content are less messy and we can be sure we've caught all occurrences of the old name).